### PR TITLE
output correct path for each publication md file

### DIFF
--- a/lib/publications.py
+++ b/lib/publications.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     # probably could be a jina or other template
     print("PUBLICATIONS=", end='')
     for publication in publications:
-        print("\\\n   %s" % (path), end='')
+        print("\\\n   %s" % (publication), end='')
     print("\n")
 
     print("FEATURES=", end='')


### PR DESCRIPTION
Currently `make makefiles` produces
```
PUBLICATIONS=\
   data/publication/national-park-boundary.md\
   data/publication/national-park-boundary.md\
   data/publication/national-park-boundary.md\
   data/publication/national-park-boundary.md\
   data/publication/national-park-boundary.md\
   data/publication/national-park-boundary.md
```

With fix that'd be
```
PUBLICATIONS=\
   data/publication/green-belt.md\
   data/publication/historic-landfill.md\
   data/publication/lambeth-wards.md\
   data/publication/local-authority-districts.md\
   data/publication/mayoral-development-corporation-boundary.md\
   data/publication/national-park-boundary.md
```