### PR TITLE
Inspire licence

### DIFF
--- a/data/licence/index.tsv
+++ b/data/licence/index.tsv
@@ -1,6 +1,7 @@
 path
 environment-agency-conditional.md
 historic-england.md
+inspire-end-user-licence.md
 land-registry-inspire.md
 ogl.md
 unknown.md

--- a/data/licence/index.tsv
+++ b/data/licence/index.tsv
@@ -1,7 +1,7 @@
 path
 environment-agency-conditional.md
 historic-england.md
-inspire-end-user-licence.md
+inspire-end-user.md
 land-registry-inspire.md
 ogl.md
 unknown.md

--- a/data/licence/inspire-end-user-licence.md
+++ b/data/licence/inspire-end-user-licence.md
@@ -1,0 +1,5 @@
+---
+licence: inspire-end-user-licence
+name: Inspire End User Licence
+url: https://www.ordnancesurvey.co.uk/business-and-government/public-sector/mapping-agreements/inspire-licence.html
+---

--- a/data/licence/inspire-end-user.md
+++ b/data/licence/inspire-end-user.md
@@ -1,5 +1,5 @@
 ---
-licence: inspire-end-user-licence
-name: Inspire End User Licence
+licence: inspire-end-user
+name: INSPIRE End User Licence
 url: https://www.ordnancesurvey.co.uk/business-and-government/public-sector/mapping-agreements/inspire-licence.html
 ---

--- a/data/publication/tree-preservation-order/tree-preservation-order-1.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-1.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:1
 name: Tree Preservation Order - Collection of Trees
 organisation: national-park:1
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: e4f28b41-1a63-4bf6-b807-8279402473c1
 documentation-url: 
 data-url: http://inspire.misoportal.com/geoserver/peak_district_national_park_pdnpa-tpo-area/wfs?service=wfs&version=2.0.0&request=GetFeature&typename=peak_district_national_park_pdnpa-tpo-area:peak_district_national_park_pdnpa-tpo-area&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-4.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-4.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:4
 name: NYMNPA Tree Preservation Orders - Individual trees
 organisation: national-park:4
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: c2851267-444a-41dd-8067-badd1be36671
 documentation-url: 
 data-url: http://inspire.nationalparks.gov.uk/geoserver/nymnpa_inspire/ows?service=WFS&request=GetFeature&typename=nymnpa_inspire:nymnpa-tpo_areas&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-5.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-5.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:5
 name: YDNPA Tree Preservation Orders
 organisation: national-park:5
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 717dd67c-f7eb-43bb-abef-db8600402b28
 documentation-url: 
 data-url: http://inspire.nationalparks.gov.uk/geoserver/ydnpa_inspire/ows?service=WFS&request=GetFeature&typename=ydnpa_inspire:ydnpa_tpo&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-7.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-7.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:7
 name: NNPA Tree Preservation Orders
 organisation: national-park:7
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 7d394432-fff2-4e7d-86ae-c789cd1d367d
 documentation-url: 
 data-url: http://inspire.nationalparks.gov.uk/geoserver/nnpa_inspire/ows?service=WFS&request=GetFeature&typename=nnpa_inspire:nnpa_tpo&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-BAN.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-BAN.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:BAN
 name: Tree Preservation Orders within Basingstoke & Deane Borough Council Area
 organisation: local-authority-eng:BAN
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 649db94c-f017-4e31-a858-fbd24a6dbadf
 documentation-url: 
 data-url: http://inspire.misoportal.com/geoserver/basingstoke_deane_borough_council_tpo_area/wfs?service=wfs&version=2.0.0&request=GetFeature&typename=basingstoke_deane_borough_council_tpo_area:basingstoke_deane_borough_council_tpo_area&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-BAR.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-BAR.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:BAR
 name: Tree Preservation Orders
 organisation: local-authority-eng:BAR
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 67fafb07-dbbc-468e-925f-d0b887e488ce
 documentation-url: 
 data-url: https://webgis1.barrowbc.gov.uk/inspire/wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=INSPIRE:TPOS&outputFormat=GML32

--- a/data/publication/tree-preservation-order/tree-preservation-order-BAS.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-BAS.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:BAS
 name: Tree Preservation Orders (TPO's)
 organisation: local-authority-eng:BAS
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: b7df2eb7-9dd7-4f38-be81-a39b88e68e7d
 documentation-url: 
 data-url: http://feeds.getmapping.com/665.wfsx?service=wfs&version=1.0.0&request=getcapabilities&typename=TPOS&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-BLA.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-BLA.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:BLA
 name: Tree Preservation Orders
 organisation: local-authority-eng:BLA
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: a7be7b49-f95a-4afe-8d38-d8af6df4a8f5
 documentation-url: 
 data-url: http://w3.blaby.gov.uk/geoserver/inspire/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=inspire:tree_preservation_orders&maxFeatures=50&outputFormat=application%2Fgml%2Bxml%3B+version%3D3.2

--- a/data/publication/tree-preservation-order/tree-preservation-order-BPL.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-BPL.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:BPL
 name: Tree Preservation Orders
 organisation: local-authority-eng:BPL
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 3d3876bb-f787-45cb-8874-15806fddd76f
 documentation-url: 
 data-url: https://w3.blackpool.gov.uk/geoserver/inspire/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=inspire:tpo&maxFeatures=50&outputFormat=application%2Fgml%2Bxml%3B+version%3D3.2

--- a/data/publication/tree-preservation-order/tree-preservation-order-BST.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-BST.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:BST
 name: Tree Preservation Orders
 organisation: local-authority-eng:BST
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: cb68d400-4b91-4227-b68a-8c9bf0744724
 documentation-url: 
 data-url: http://maps.bristol.gov.uk/arcgis/services/ext/INSPIRE/MapServer/WFSServer?service=WFS&request=GetFeature&typename=INSPIREWFS:Tree_preservation_order_-_trunk&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-CHE.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-CHE.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:CHE
 name: CE TPO points
 organisation: local-authority-eng:CHE
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 7e2bdb45-7063-4e96-ae35-3c166edab35b
 documentation-url: 
 data-url: http://maps.cheshire.gov.uk/ArcGIS/services/CE/public_wfs/MapServer/WFSServer?request=GetFeature&service=WFS&typename=CE_public_wfs:TPO_layer__live__-_Regions&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-COP.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-COP.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:COP
 name: Local Plan - Tree Preservation Orders
 organisation: local-authority-eng:COP
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: ab52e552-2701-4f7d-8ced-5c0162d7287b
 documentation-url: 
 data-url: http://gistch1.copelandbc.org.uk/geoserver/INSPIRE/wfs?service=WFS&version=2.0.0&request=GetFeature&typeName=INSPIRE:TPOs_PlanArea&outputFormat=GML32

--- a/data/publication/tree-preservation-order/tree-preservation-order-DAV.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-DAV.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:DAV
 name: Daventry District Council - Tree Preservation Orders Trees
 organisation: local-authority-eng:DAV
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: d40e0259-1144-40f8-9b2f-7fb3647c6419
 documentation-url: 
 data-url: https://feeds.getmapping.com/54236.wfsx?service=wfs&version=1.0.0&request=getcapabilities&typename=tpo_tree&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-EPS.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-EPS.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:EPS
 name: Tree Preservation Orders
 organisation: local-authority-eng:EPS
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: d0dff219-8001-4ea5-9391-2b04da1b34ac
 documentation-url: 
 data-url: http://myeebc.epsom-ewell.gov.uk/getOWS.ashx?MapSource=EEBC/inspire&service=WFS&version=1.1.0&request=GetFeature&TypeName=TPO&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-FOR.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-FOR.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:FOR
 name: Forest Heath District Council Tree Preservation Orders
 organisation: local-authority-eng:FOR
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 1daa0098-3279-425d-8c60-f39ddac738b4
 documentation-url: 
 data-url: http://maps.westsuffolk.gov.uk/GetOWS.ashx?VERSION=1.1.0&MAPSOURCE=WestSuffolk/INSPIRE&REQUEST=GetFeature&SERVICE=WFS&typename=tpo&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-HAA.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-HAA.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:HAA
 name: Havant TPO Points
 organisation: local-authority-eng:HAA
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 8a274436-4e34-4688-8572-2c9bbf6ad1ac
 documentation-url: 
 data-url: http://inspire.misoportal.com/geoserver/havant_borough_council_havant_tpo/wfs?service=wfs&version=2.0.0&request=GetFeature&typename=havant_borough_council_havant_tpo:havant_borough_council_havant_tpo&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-HAL.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-HAL.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:HAL
 name: Halton Tree Preservation Orders
 organisation: local-authority-eng:HAL
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 0a255782-f9bc-47f7-85f7-8296362d5c32
 documentation-url: 
 data-url: http://inspire.halton.gov.uk/geoserver/wfs?service=WFS&request=GetFeature&typename=inspire:tree_preservation_orders_polygon&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-KET.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-KET.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:KET
 name: Tree Preservation Orders
 organisation: local-authority-eng:KET
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: abc51bca-0f8b-4212-8ab4-219ccc7bb649
 documentation-url: 
 data-url: http://maps.kettering.gov.uk/inspirewfs/wfs.impl?service=wfs&version=2.0.0&request=GetFeature&typename=KBC:Tree_Preservation_Orders&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-KWL.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-KWL.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:KWL
 name: Knowsley Tree Preservation Orders
 organisation: local-authority-eng:KWL
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 7377b1d9-53e4-457d-b259-75f8d23e90d8
 documentation-url: 
 data-url: http://kgeo.knowsley.gov.uk:8080/geoserver/Inspire/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=Inspire:inspire_ufrm_tpo&maxFeatures=50&outputFormat=SHAPE-ZIP

--- a/data/publication/tree-preservation-order/tree-preservation-order-MIK.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-MIK.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:MIK
 name: Tree Preservation Orders - Areas
 organisation: local-authority-eng:MIK
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: bef67f65-92ef-4566-b64d-76062492d8f0
 documentation-url: 
 data-url: http://mapping.milton-keynes.gov.uk/GetOWS.ashx?MAPSOURCE=MiltonKeynes/inspire&version=1.1.0&request=GetFeature&service=WFS&TypeName=tpo_regions&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-NDE.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-NDE.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:NDE
 name: Tree Preservation Orders
 organisation: local-authority-eng:NDE
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 82169bcb-3e7a-4019-9390-b7c03fcdcd6f
 documentation-url: 
 data-url: http://inspire.northdevon.gov.uk/geoserver/ows?service=wfs&version=2.0.0&request=GetFeature&typename=Inspire:Tree_Preservation_Orders&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-NNO.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-NNO.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:NNO
 name: North Norfolk District Council Tree Preservation Orders
 organisation: local-authority-eng:NNO
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 731205e7-2204-4778-917e-9c01bca6e737
 documentation-url: 
 data-url: http://maps.norfolk.gov.uk/inspire/data/north_norfolk_district_council/TreePreservationOrders/NNDC_Tree_Preservation_Orders.kml

--- a/data/publication/tree-preservation-order/tree-preservation-order-OLD.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-OLD.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:OLD
 name: Tree Preservation Orders
 organisation: local-authority-eng:OLD
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 3cb58e95-e5bb-4a6f-8322-ee408197da93
 documentation-url: 
 data-url: http://inspire.oldham.gov.uk:8080/geoserver/wfs?service=WFS&request=GetFeature&typename=Oldham:Tree_Preservation_Order&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-RIB.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-RIB.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:RIB
 name: Tree Preservation Orders
 organisation: local-authority-eng:RIB
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 6bf12541-d261-4dcc-80eb-719f72827443
 documentation-url: 
 data-url: http://inspire.ribblevalley.gov.uk/geoserver/inspire/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=inspire:tree_preservation_order&maxFeatures=50&outputFormat=application%2Fgml%2Bxml%3B+version%3D3.2

--- a/data/publication/tree-preservation-order/tree-preservation-order-SAL.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-SAL.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:SAL
 name: St Albans City and District Council Tree Preservation Orders
 organisation: local-authority-eng:SAL
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 55a14122-42e6-422c-b649-b6b24d16793e
 documentation-url: 
 data-url: http://inspirewfs.stalbans.gov.uk/INSPIRE/WEBSERVICE/wfs.exe?service=wfs&request=GetFeature&typename=ns:Tree_Preservation_Orders&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-SCE.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-SCE.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:SCE
 name: Scarborough Borough Council Tree Preservation Order Points
 organisation: local-authority-eng:SCE
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 27e9ae2e-7255-42b5-bf13-c121a75a3bb1
 documentation-url: 
 data-url: http://maps.scarborough.gov.uk/geoserver/inspire/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&typename=inspire:TPO_polygon&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-SED.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-SED.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:SED
 name: St Edmundsbury Borough Council Tree Preservation Orders
 organisation: local-authority-eng:SED
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: d0a06e3f-64df-4764-9c38-6f92ad56e413
 documentation-url: 
 data-url: http://maps.westsuffolk.gov.uk/GetOWS.ashx?VERSION=1.1.0&MAPSOURCE=WestSuffolk/INSPIRE&REQUEST=GetFeature&SERVICE=WFS&typename=tpo&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-SEV.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-SEV.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:SEV
 name: Sevenoaks Open Data - Tree Preservation Orders (TPOs)
 organisation: local-authority-eng:SEV
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 0b4b5448-0903-449a-9569-7b906b47da05
 documentation-url: 
 data-url: http://gisopendata-sdc.opendata.arcgis.com/datasets/3b347a126ff74237ade93b487e30f659_0.geojson

--- a/data/publication/tree-preservation-order/tree-preservation-order-SLF.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-SLF.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:SLF
 name: Tree Preservation Orders
 organisation: local-authority-eng:SLF
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 906d9a7c-4495-4a95-a378-0ae2e81aab3a
 documentation-url: 
 data-url: http://map.salford.gov.uk/geoserver/INSPIRE/ows?service=wfs&version=2.0.0&request=GetFeature&typename=INSPIRE:ENV_TPO&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-TFW.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-TFW.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:TFW
 name: Tree Preservation Orders
 organisation: local-authority-eng:TFW
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: a1af24b0-cc05-45b7-a121-454817510490
 documentation-url: 
 data-url: http://inspire.misoportal.com/geoserver/telford_and_wrekin_coucil_tpo/wfs?service=wfs&version=2.0.0&request=GetFeature&typename=telford_and_wrekin_coucil_tpo:telford_and_wrekin_coucil_tpo&outputFormat=GML2

--- a/data/publication/tree-preservation-order/tree-preservation-order-TUN.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-TUN.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:TUN
 name: Tunbridge Wells Open Data - Tree Preservation Orders
 organisation: local-authority-eng:TUN
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 19ca2582-8e58-4c7f-8297-a1781bfd7b4d
 documentation-url: 
 data-url: http://opendatanew-tunbridgewells.opendata.arcgis.com/datasets/b8add41804c44aeda117263c56835ee2_0.geojson

--- a/data/publication/tree-preservation-order/tree-preservation-order-WGN.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-WGN.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:WGN
 name: Tree Preservation Orders - Areas
 organisation: local-authority-eng:WGN
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: c2a1f930-695a-4616-9615-64a39a5b07db
 documentation-url: 
 data-url: http://opendata.wigan.gov.uk/datasets/036f4c98cdbf40e9afb7a3a76248c7c2_1.geojson

--- a/data/publication/tree-preservation-order/tree-preservation-order-WYO.md
+++ b/data/publication/tree-preservation-order/tree-preservation-order-WYO.md
@@ -3,7 +3,7 @@ publication: tree-preservation-order:WYO
 name: Tree Preservation Order
 organisation: local-authority-eng:WYO
 copyright: 
-licence: inpsire
+licence: inspire
 data-gov-uk: 90a7804d-7f2d-4663-83e0-c970cce05cba
 documentation-url: 
 data-url: http://inspire.wycombe.gov.uk/getows.ashx?Mapsource=Wycombe%2FInspire&service=WFS&version=1.1.0&Request=GetFeature&TypeName=TreePreservationOrder&outputFormat=GML2


### PR DESCRIPTION
* Add an inspire licence, different to the land registry inspire licence, that a lot of the local authority datasets seem to point to.
* fix inspire typo in TPOs