### PR TITLE
ubuntu pip freeze adds pkg-resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ docutils==0.14
 idna==2.6
 lockfile==0.12.2
 luigi==2.7.5
-pkg-resources==0.0.0
 python-daemon==2.1.2
 python-frontmatter==0.4.2
 pyproj==1.9.5.1


### PR DESCRIPTION
pip freeze on ubuntu adding pkg-resources to requirements which causes install to fail.

https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463